### PR TITLE
MongoDB-ify this Style Guide

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,7 +8,7 @@ run:
 linters:
   enable:
     - errcheck
-    - goimports
+    - gofumpt
     - govet
     - revive
     - staticcheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,8 +9,8 @@ linters:
   enable:
     - errcheck
     - goimports
-    - golint
     - govet
+    - revive
     - staticcheck
 
 issues:

--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,1 @@
+Dave Rolsky <dave.rolsky@mongodb.com> <autarch@urth.org>

--- a/CHANGELOG-MongoDB.md
+++ b/CHANGELOG-MongoDB.md
@@ -2,3 +2,4 @@
 
 - Recommend the new atomic types like `atomic.Bool` instead of the `go.uber.org/atomic` package.
 - Replace recommendation to use `golint` with `revive`, as `golint` is long since deprecated.
+- Replace recommendation to use `goimports` with `gofumpt`.

--- a/CHANGELOG-MongoDB.md
+++ b/CHANGELOG-MongoDB.md
@@ -7,3 +7,4 @@
 - Added a recommendation to use `gopls` in general, and specifically to configure your editor to use
   it to update imports.
 - Added a recommendation to use `golangci-lint` or `nogo` to `intro.md`.
+- Updated the `CODE_OF_CONDUCT.md` to use the same one we use for the MongoDB Node driver.

--- a/CHANGELOG-MongoDB.md
+++ b/CHANGELOG-MongoDB.md
@@ -6,3 +6,4 @@
   intro to use `gofumpt` instead.
 - Added a recommendation to use `gopls` in general, and specifically to configure your editor to use
   it to update imports.
+- Added a recommendation to use `golangci-lint` or `nogo` to `intro.md`.

--- a/CHANGELOG-MongoDB.md
+++ b/CHANGELOG-MongoDB.md
@@ -1,3 +1,4 @@
 # 2025-01-31
 
 - Recommend the new atomic types like `atomic.Bool` instead of the `go.uber.org/atomic` package.
+- Replace recommendation to use `golint` with `revive`, as `golint` is long since deprecated.

--- a/CHANGELOG-MongoDB.md
+++ b/CHANGELOG-MongoDB.md
@@ -3,3 +3,5 @@
 - Recommend the new atomic types like `atomic.Bool` instead of the `go.uber.org/atomic` package.
 - Replace recommendation to use `golint` with `revive`, as `golint` is long since deprecated.
 - Replace recommendation to use `goimports` with `gofumpt`.
+- Added a recommendation to use `gopls` in general, and specifically to configure your editor to use
+  it to update imports.

--- a/CHANGELOG-MongoDB.md
+++ b/CHANGELOG-MongoDB.md
@@ -2,6 +2,7 @@
 
 - Recommend the new atomic types like `atomic.Bool` instead of the `go.uber.org/atomic` package.
 - Replace recommendation to use `golint` with `revive`, as `golint` is long since deprecated.
-- Replace recommendation to use `goimports` with `gofumpt`.
+- Replace recommendation to use `goimports` with `gofumpt`. Also fixed a reference to `gofmt` in the
+  intro to use `gofumpt` instead.
 - Added a recommendation to use `gopls` in general, and specifically to configure your editor to use
   it to update imports.

--- a/CHANGELOG-MongoDB.md
+++ b/CHANGELOG-MongoDB.md
@@ -1,0 +1,3 @@
+# 2025-01-31
+
+- Recommend the new atomic types like `atomic.Bool` instead of the `go.uber.org/atomic` package.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,7 +55,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at oss-conduct@uber.com. All
+reported by contacting the project team at ??? <!-- does MongoDB have an email for OSS CoC issues? -->. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,15 +1,17 @@
-# Contributor Covenant Code of Conduct
+## Code of Conduct
 
-## Our Pledge
+### Our Pledge
 
 In the interest of fostering an open and welcoming environment, we as
 contributors and maintainers pledge to making participation in our project and
-our community a harassment-free experience for everyone, regardless of age, body
-size, disability, ethnicity, sex characteristics, gender identity and expression,
-level of experience, education, socio-economic status, nationality, personal
-appearance, race, religion, or sexual identity and orientation.
+our community a harassment-free experience for everyone, regardless of age,
+body size, disability, ethnicity, gender identity and expression, level of
+experience, nationality, personal appearance, race, religion, or sexual
+identity and orientation.
 
-## Our Standards
+Please also take a moment to review [MongoDB's core values][mdb-core-values].
+
+### Our Standards
 
 Examples of behavior that contributes to creating a positive environment
 include:
@@ -23,15 +25,15 @@ include:
 Examples of unacceptable behavior by participants include:
 
 * The use of sexualized language or imagery and unwelcome sexual attention or
- advances
+advances
 * Trolling, insulting/derogatory comments, and personal or political attacks
 * Public or private harassment
 * Publishing others' private information, such as a physical or electronic
- address, without explicit permission
+  address, without explicit permission
 * Other conduct which could reasonably be considered inappropriate in a
- professional setting
+  professional setting
 
-## Our Responsibilities
+### Our Responsibilities
 
 Project maintainers are responsible for clarifying the standards of acceptable
 behavior and are expected to take appropriate and fair corrective action in
@@ -43,34 +45,36 @@ that are not aligned to this Code of Conduct, or to ban temporarily or
 permanently any contributor for other behaviors that they deem inappropriate,
 threatening, offensive, or harmful.
 
-## Scope
+### Scope
 
 This Code of Conduct applies both within project spaces and in public spaces
 when an individual is representing the project or its community. Examples of
 representing a project or community include using an official project e-mail
-address, posting via an official social media account, or acting as an appointed
-representative at an online or offline event. Representation of a project may be
-further defined and clarified by project maintainers.
+address, posting via an official social media account, or acting as an
+appointed representative at an online or offline event. Representation of a
+project may be further defined and clarified by project maintainers.
 
-## Enforcement
+### Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at ??? <!-- does MongoDB have an email for OSS CoC issues? -->. All
-complaints will be reviewed and investigated and will result in a response that
-is deemed necessary and appropriate to the circumstances. The project team is
-obligated to maintain confidentiality with regard to the reporter of an incident.
+reported by contacting the project team, or by
+[contacting GitHub][github-report-abuse]. All complaints will be reviewed
+and investigated and will result in a response that is deemed necessary and
+appropriate to the circumstances. The project team is obligated to maintain
+confidentiality with regard to the reporter of an incident.
 Further details of specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good
 faith may face temporary or permanent repercussions as determined by other
 members of the project's leadership.
 
-## Attribution
+### Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
-available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version [1.4][version].
 
-[homepage]: https://www.contributor-covenant.org
 
-For answers to common questions about this code of conduct, see
-https://www.contributor-covenant.org/faq
+[github-report-abuse]: https://github.com/contact/report-abuse
+[homepage]: https://www.contributor-covenant.org/
+[mdb-core-values]: https://www.mongodb.com/company/
+[version]: https://www.contributor-covenant.org/version/1/4/

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ patterns and conventions used in Go code at MongoDB.
 
 See [MongoDB Go Style Guide](style.md) for the style guide.
 
+<!--
+
 ## Translations
 
 We are aware of the following translations of this guide by the Go community.
@@ -26,3 +28,5 @@ We are aware of the following translations of this guide by the Go community.
 - **Tiếng việt** (Vietnamese): [nc-minh/uber-go-guide-vi](https://github.com/nc-minh/uber-go-guide-vi)
 
 If you have a translation, feel free to submit a PR adding it to the list.
+
+-->

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-This repository holds the [Uber Go Style Guide](style.md), which documents
-patterns and conventions used in Go code at Uber.
+This repository holds the [MongoDB Go Style Guide](style.md), which documents
+patterns and conventions used in Go code at MongoDB.
 
 ## Style Guide
 
-See [Uber Go Style Guide](style.md) for the style guide.
+See [MongoDB Go Style Guide](style.md) for the style guide.
 
 ## Translations
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,16 @@ patterns and conventions used in Go code at MongoDB.
 
 See [MongoDB Go Style Guide](style.md) for the style guide.
 
+## MongoDB-Specific Changes
+
+At MongoDB, we aim to keep this guide as close to the upstream guide maintained by Uber as
+possible. However, there will inevitable by some points of divergence over time as we develop our
+own coding standards.
+
+When you make a change specific to this MongoDB fork, always update the
+[`CHANGELOG-MongoDB.md`](./CHANGELOG-MongoDB.md) file with a summary of what you changed. This makes
+it easier to reconcile differences between the Uber and MongoDB versions of this style guide.
+
 <!--
 
 ## Translations

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -1,4 +1,4 @@
-# Uber Go Style Guide
+# MongoDB Go Style Guide
 
 - [Introduction](intro.md)
 - Guidelines

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -18,7 +18,7 @@
     - [Handle Errors Once](error-once.md)
   - [Handle Type Assertion Failures](type-assert.md)
   - [Don't Panic](panic.md)
-  - [Use go.uber.org/atomic](atomic.md)
+  - [Use the New Types in sync/atomic](atomic.md)
   - [Avoid Mutable Globals](global-mut.md)
   - [Avoid Embedding Types in Public Structs](embed-public.md)
   - [Avoid Using Built-In Names](builtin-name.md)

--- a/src/atomic.md
+++ b/src/atomic.md
@@ -1,14 +1,24 @@
-# Use go.uber.org/atomic
+<!-- This entirely replaces Uber's version of this file, which recommends the use of
+go.uber.org/atomic. That package predates the new types added in Go 1.19. The new stdlib types
+provide more or less the same functionality as Uber's package. -->
 
-Atomic operations with the [sync/atomic] package operate on the raw types
-(`int32`, `int64`, etc.) so it is easy to forget to use the atomic operation to
-read or modify the variables.
+# Use the New Types in sync/atomic
 
-[go.uber.org/atomic] adds type safety to these operations by hiding the
-underlying type. Additionally, it includes a convenient `atomic.Bool` type.
+In the past, the [sync/atomic] package was implemented entirely in terms of functions like
+`atomic.AddInt64`, which were awkward to use and made it easy to accidentally access the underlying
+value non-atomically..
 
-  [go.uber.org/atomic]: https://pkg.go.dev/go.uber.org/atomic
-  [sync/atomic]: https://pkg.go.dev/sync/atomic
+Since Go 1.19, the [sync/atomic] package provides atomic types like `atomic.Bool` and
+`atomic.Int64`, which provide a much safer API for atomic operations, making it impossible to read
+or modify them with a non-atomic operation.
+
+<!--
+
+TODO: It'd be nice to have a shared library that provided a typed atomic value instead of having
+people use `atomic.Value`. We've written such a thing for Mongosync. See
+https://github.com/10gen/mongosync/blob/main/mongo-go/msync/typed_atomic.go for details.
+
+-->
 
 <table>
 <thead><tr><th>Bad</th><th>Good</th></tr></thead>
@@ -17,7 +27,7 @@ underlying type. Additionally, it includes a convenient `atomic.Bool` type.
 
 ```go
 type foo struct {
-  running int32  // atomic
+  running atomic.Int32  // atomic
 }
 
 func (f* foo) start() {

--- a/src/import-group.md
+++ b/src/import-group.md
@@ -5,7 +5,7 @@ There should be two import groups:
 - Standard library
 - Everything else
 
-This is the grouping applied by goimports by default.
+This is the grouping applied by gopls by default.
 
 <table>
 <thead><tr><th>Bad</th><th>Good</th></tr></thead>

--- a/src/intro.md
+++ b/src/intro.md
@@ -35,3 +35,10 @@ recommend setting up your editor to:
 
 You can find information in editor support for Go tools here:
 <https://go.dev/wiki/IDEsAndTextEditorPlugins>
+
+## MongoDB Style
+
+This style guide is a fork of the [Uber Style Guide](https://github.com/uber-go/guide) maintained by
+MongoDB. It is largely the same as Uber's. All changes specific to MongoDB are noted in the
+[CHANGELOG-MongoDB.md](./CHANGELOG-MongoDB.md) file. In addition, we have used HTML comments to make
+notes wherever we have made changes from the Uber version.

--- a/src/intro.md
+++ b/src/intro.md
@@ -27,9 +27,14 @@ resources:
 We aim for the code samples to be accurate for the two most recent minor versions
 of Go [releases](https://go.dev/doc/devel/release).
 
+You should set up your editor to integrate with Go's LSP server, [gopls].
+
+  [gopls]: https://github.com/golang/tools/tree/master/gopls
+
 All code should be error-free when run through `revive` and `go vet`. We
 recommend setting up your editor to:
 
+- Use `gopls` to update your code's imports automatically on save
 - Run `gofumpt` on save
 - Run `revive` and `go vet` to check for errors
 

--- a/src/intro.md
+++ b/src/intro.md
@@ -30,7 +30,7 @@ of Go [releases](https://go.dev/doc/devel/release).
 All code should be error-free when run through `revive` and `go vet`. We
 recommend setting up your editor to:
 
-- Run `goimports` on save
+- Run `gofumpt` on save
 - Run `revive` and `go vet` to check for errors
 
 You can find information in editor support for Go tools here:

--- a/src/intro.md
+++ b/src/intro.md
@@ -2,7 +2,7 @@
 
 Styles are the conventions that govern our code. The term style is a bit of a
 misnomer, since these conventions cover far more than just source file
-formatting—gofmt handles that for us.
+formatting—gofumpt handles that for us.
 
 The goal of this guide is to manage this complexity by describing in detail the
 Dos and Don'ts of writing Go code at Uber. These rules exist to keep the code

--- a/src/intro.md
+++ b/src/intro.md
@@ -38,6 +38,16 @@ recommend setting up your editor to:
 - Run `gofumpt` on save
 - Run `revive` and `go vet` to check for errors
 
+<!-- BEGIN MongoDB addition -->
+
+Note that you may wish to use [golangci-lint] or Bazel's [nogo] to run `gofumpt`, `revive`, and `go
+vet` instead of running each one separately.
+
+  [golangci-lint]: https://golangci-lint.run/
+  [nogo]: https://github.com/bazel-contrib/rules_go/blob/master/go/nogo.rst
+
+<!-- END MongoDB addition -->
+
 You can find information in editor support for Go tools here:
 <https://go.dev/wiki/IDEsAndTextEditorPlugins>
 

--- a/src/intro.md
+++ b/src/intro.md
@@ -27,11 +27,11 @@ resources:
 We aim for the code samples to be accurate for the two most recent minor versions
 of Go [releases](https://go.dev/doc/devel/release).
 
-All code should be error-free when run through `golint` and `go vet`. We
+All code should be error-free when run through `revive` and `go vet`. We
 recommend setting up your editor to:
 
 - Run `goimports` on save
-- Run `golint` and `go vet` to check for errors
+- Run `revive` and `go vet` to check for errors
 
 You can find information in editor support for Go tools here:
 <https://go.dev/wiki/IDEsAndTextEditorPlugins>

--- a/src/lint.md
+++ b/src/lint.md
@@ -9,14 +9,14 @@ quality without being unnecessarily prescriptive:
 
 - [errcheck] to ensure that errors are handled
 - [goimports] to format code and manage imports
-- [golint] to point out common style mistakes
 - [govet] to analyze code for common mistakes
+- [revive] to point out common style mistakes
 - [staticcheck] to do various static analysis checks
 
   [errcheck]: https://github.com/kisielk/errcheck
   [goimports]: https://pkg.go.dev/golang.org/x/tools/cmd/goimports
-  [golint]: https://github.com/golang/lint
   [govet]: https://pkg.go.dev/cmd/vet
+  [revive]: https://github.com/mgechev/revive
   [staticcheck]: https://staticcheck.dev
 
 ## Lint Runners

--- a/src/lint.md
+++ b/src/lint.md
@@ -8,13 +8,13 @@ help to catch the most common issues and also establish a high bar for code
 quality without being unnecessarily prescriptive:
 
 - [errcheck] to ensure that errors are handled
-- [goimports] to format code and manage imports
+- [gofumpt] to format code and manage imports
 - [govet] to analyze code for common mistakes
 - [revive] to point out common style mistakes
 - [staticcheck] to do various static analysis checks
 
   [errcheck]: https://github.com/kisielk/errcheck
-  [goimports]: https://pkg.go.dev/golang.org/x/tools/cmd/goimports
+  [gofumpt]: https://github.com/mvdan/gofumpt
   [govet]: https://pkg.go.dev/cmd/vet
   [revive]: https://github.com/mgechev/revive
   [staticcheck]: https://staticcheck.dev

--- a/src/lint.md
+++ b/src/lint.md
@@ -21,7 +21,10 @@ quality without being unnecessarily prescriptive:
 
 ## Lint Runners
 
-We recommend [golangci-lint] as the go-to lint runner for Go code, largely due
+For projects which use Bazel, you should use [nogo] instead of [golangci-lint], as [golangci-lint]
+does not work well with Bazel's sandboxing.
+
+Otherwise, we recommend [golangci-lint] as the go-to lint runner for Go code, largely due
 to its performance in larger codebases and ability to configure and use many
 canonical linters at once. This repo has an example [.golangci.yml] config file
 with recommended linters and settings.
@@ -30,6 +33,7 @@ golangci-lint has [various linters] available for use. The above linters are
 recommended as a base set, and we encourage teams to add any additional linters
 that make sense for their projects.
 
+  [nogo]: https://github.com/bazel-contrib/rules_go/blob/master/go/nogo.rst
   [golangci-lint]: https://github.com/golangci/golangci-lint
   [.golangci.yml]: https://github.com/uber-go/guide/blob/master/.golangci.yml
   [various linters]: https://golangci-lint.run/usage/linters/

--- a/style.md
+++ b/style.md
@@ -5,7 +5,7 @@
 
 <!-- markdownlint-disable MD033 -->
 
-# Uber Go Style Guide
+# MongoDB Go Style Guide
 
 - [Introduction](#introduction)
 - [Guidelines](#guidelines)
@@ -106,6 +106,13 @@ recommend setting up your editor to:
 
 You can find information in editor support for Go tools here:
 https://go.dev/wiki/IDEsAndTextEditorPlugins
+
+### MongoDB Style
+
+This style guide is a fork of the [Uber Style Guide](https://github.com/uber-go/guide) maintained by
+MongoDB. It is largely the same as Uber's. All changes specific to MongoDB are noted in the
+[CHANGELOG-MongoDB.md](src/CHANGELOG-MongoDB.md) file. In addition, we have used HTML comments to make
+notes wherever we have made changes from the Uber version.
 
 ## Guidelines
 

--- a/style.md
+++ b/style.md
@@ -25,7 +25,7 @@
     - [Handle Errors Once](#handle-errors-once)
   - [Handle Type Assertion Failures](#handle-type-assertion-failures)
   - [Don't Panic](#dont-panic)
-  - [Use the New Types in sync/atomic](#use-the-new-types-in-syncatomic)
+  - [Use the New Types in sync/atomic](#use-the-new-types-in-syncatomic-1)
   - [Avoid Mutable Globals](#avoid-mutable-globals)
   - [Avoid Embedding Types in Public Structs](#avoid-embedding-types-in-public-structs)
   - [Avoid Using Built-In Names](#avoid-using-built-in-names)
@@ -98,9 +98,12 @@ resources:
 We aim for the code samples to be accurate for the two most recent minor versions
 of Go [releases](https://go.dev/doc/devel/release).
 
+You should set up your editor to integrate with Go's LSP server, [gopls](https://github.com/golang/tools/tree/master/gopls).
+
 All code should be error-free when run through `revive` and `go vet`. We
 recommend setting up your editor to:
 
+- Use `gopls` to update your code's imports automatically on save
 - Run `gofumpt` on save
 - Run `revive` and `go vet` to check for errors
 
@@ -1252,6 +1255,12 @@ if err != nil {
 </tbody></table>
 
 ### Use the New Types in sync/atomic
+
+<!-- This entirely replaces Uber's version of this file, which recommends the use of
+go.uber.org/atomic. That package predates the new types added in Go 1.19. The new stdlib types
+provide more or less the same functionality as Uber's package. -->
+
+#### Use the New Types in sync/atomic
 
 In the past, the [sync/atomic] package was implemented entirely in terms of functions like
 `atomic.AddInt64`, which were awkward to use and made it easy to accidentally access the underlying
@@ -2586,7 +2595,7 @@ There should be two import groups:
 - Standard library
 - Everything else
 
-This is the grouping applied by goimports by default.
+This is the grouping applied by gopls by default.
 
 <table>
 <thead><tr><th>Bad</th><th>Good</th></tr></thead>

--- a/style.md
+++ b/style.md
@@ -98,11 +98,11 @@ resources:
 We aim for the code samples to be accurate for the two most recent minor versions
 of Go [releases](https://go.dev/doc/devel/release).
 
-All code should be error-free when run through `golint` and `go vet`. We
+All code should be error-free when run through `revive` and `go vet`. We
 recommend setting up your editor to:
 
 - Run `goimports` on save
-- Run `golint` and `go vet` to check for errors
+- Run `revive` and `go vet` to check for errors
 
 You can find information in editor support for Go tools here:
 https://go.dev/wiki/IDEsAndTextEditorPlugins
@@ -4108,8 +4108,8 @@ quality without being unnecessarily prescriptive:
 
 - [errcheck](https://github.com/kisielk/errcheck) to ensure that errors are handled
 - [goimports](https://pkg.go.dev/golang.org/x/tools/cmd/goimports) to format code and manage imports
-- [golint](https://github.com/golang/lint) to point out common style mistakes
 - [govet](https://pkg.go.dev/cmd/vet) to analyze code for common mistakes
+- [revive](https://github.com/mgechev/revive) to point out common style mistakes
 - [staticcheck](https://staticcheck.dev) to do various static analysis checks
 
 ### Lint Runners

--- a/style.md
+++ b/style.md
@@ -101,7 +101,7 @@ of Go [releases](https://go.dev/doc/devel/release).
 All code should be error-free when run through `revive` and `go vet`. We
 recommend setting up your editor to:
 
-- Run `goimports` on save
+- Run `gofumpt` on save
 - Run `revive` and `go vet` to check for errors
 
 You can find information in editor support for Go tools here:
@@ -4107,7 +4107,7 @@ help to catch the most common issues and also establish a high bar for code
 quality without being unnecessarily prescriptive:
 
 - [errcheck](https://github.com/kisielk/errcheck) to ensure that errors are handled
-- [goimports](https://pkg.go.dev/golang.org/x/tools/cmd/goimports) to format code and manage imports
+- [gofumpt](https://github.com/mvdan/gofumpt) to format code and manage imports
 - [govet](https://pkg.go.dev/cmd/vet) to analyze code for common mistakes
 - [revive](https://github.com/mgechev/revive) to point out common style mistakes
 - [staticcheck](https://staticcheck.dev) to do various static analysis checks

--- a/style.md
+++ b/style.md
@@ -76,7 +76,7 @@
 
 Styles are the conventions that govern our code. The term style is a bit of a
 misnomer, since these conventions cover far more than just source file
-formatting—gofmt handles that for us.
+formatting—gofumpt handles that for us.
 
 The goal of this guide is to manage this complexity by describing in detail the
 Dos and Don'ts of writing Go code at Uber. These rules exist to keep the code

--- a/style.md
+++ b/style.md
@@ -107,6 +107,12 @@ recommend setting up your editor to:
 - Run `gofumpt` on save
 - Run `revive` and `go vet` to check for errors
 
+<!-- BEGIN MongoDB addition -->
+
+Note that you may wish to use [golangci-lint](https://golangci-lint.run/) or Bazel's [nogo](https://github.com/bazel-contrib/rules_go/blob/master/go/nogo.rst) to run `gofumpt`, `revive`, and `go vet` instead of running each one separately.
+
+<!-- END MongoDB addition -->
+
 You can find information in editor support for Go tools here:
 https://go.dev/wiki/IDEsAndTextEditorPlugins
 
@@ -4123,7 +4129,10 @@ quality without being unnecessarily prescriptive:
 
 ### Lint Runners
 
-We recommend [golangci-lint](https://github.com/golangci/golangci-lint) as the go-to lint runner for Go code, largely due
+For projects which use Bazel, you should use [nogo](https://github.com/bazel-contrib/rules_go/blob/master/go/nogo.rst) instead of [golangci-lint](https://github.com/golangci/golangci-lint), as [golangci-lint](https://github.com/golangci/golangci-lint)
+does not work well with Bazel's sandboxing.
+
+Otherwise, we recommend [golangci-lint](https://github.com/golangci/golangci-lint) as the go-to lint runner for Go code, largely due
 to its performance in larger codebases and ability to configure and use many
 canonical linters at once. This repo has an example [.golangci.yml](https://github.com/uber-go/guide/blob/master/.golangci.yml) config file
 with recommended linters and settings.

--- a/style.md
+++ b/style.md
@@ -25,7 +25,7 @@
     - [Handle Errors Once](#handle-errors-once)
   - [Handle Type Assertion Failures](#handle-type-assertion-failures)
   - [Don't Panic](#dont-panic)
-  - [Use go.uber.org/atomic](#use-gouberorgatomic)
+  - [Use the New Types in sync/atomic](#use-the-new-types-in-syncatomic)
   - [Avoid Mutable Globals](#avoid-mutable-globals)
   - [Avoid Embedding Types in Public Structs](#avoid-embedding-types-in-public-structs)
   - [Avoid Using Built-In Names](#avoid-using-built-in-names)
@@ -1251,15 +1251,23 @@ if err != nil {
 </td></tr>
 </tbody></table>
 
-### Use go.uber.org/atomic
+### Use the New Types in sync/atomic
 
-Atomic operations with the [sync/atomic](https://pkg.go.dev/sync/atomic) package operate on the raw types
-(`int32`, `int64`, etc.) so it is easy to forget to use the atomic operation to
-read or modify the variables.
+In the past, the [sync/atomic] package was implemented entirely in terms of functions like
+`atomic.AddInt64`, which were awkward to use and made it easy to accidentally access the underlying
+value non-atomically..
 
-[go.uber.org/atomic](https://pkg.go.dev/go.uber.org/atomic) adds type safety to these operations by hiding the
-underlying type. Additionally, it includes a convenient `atomic.Bool` type.
+Since Go 1.19, the [sync/atomic] package provides atomic types like `atomic.Bool` and
+`atomic.Int64`, which provide a much safer API for atomic operations, making it impossible to read
+or modify them with a non-atomic operation.
 
+<!--
+
+TODO: It'd be nice to have a shared library that provided a typed atomic value instead of having
+people use `atomic.Value`. We've written such a thing for Mongosync. See
+https://github.com/10gen/mongosync/blob/main/mongo-go/msync/typed_atomic.go for details.
+
+-->
 <table>
 <thead><tr><th>Bad</th><th>Good</th></tr></thead>
 <tbody>
@@ -1267,7 +1275,7 @@ underlying type. Additionally, it includes a convenient `atomic.Bool` type.
 
 ```go
 type foo struct {
-  running int32  // atomic
+  running atomic.Int32  // atomic
 }
 
 func (f* foo) start() {


### PR DESCRIPTION
This commit replaces some references to "Uber" with "MongoDB". It also adds a `CHANGELOG-MongoDB.md`
file and adds a note to the intro explaining that this Style Guide is a fork of Uber's.