### PR TITLE
MongoDB-ify this Style Guide

### DIFF
--- a/CHANGELOG-MongoDB.md
+++ b/CHANGELOG-MongoDB.md
@@ -1,0 +1,3 @@
+## 2025-02-10
+
+- First version of this fork.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,7 +55,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at oss-conduct@uber.com. All
+reported by contacting the project team at ??? <!-- does MongoDB have an email for OSS CoC issues? -->. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -2,75 +2,134 @@
 
 ## Our Pledge
 
-In the interest of fostering an open and welcoming environment, we as
-contributors and maintainers pledge to making participation in our project and
-our community a harassment-free experience for everyone, regardless of age, body
-size, disability, ethnicity, sex characteristics, gender identity and expression,
-level of experience, education, socio-economic status, nationality, personal
-appearance, race, religion, or sexual identity and orientation.
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
 
 ## Our Standards
 
-Examples of behavior that contributes to creating a positive environment
-include:
+Examples of behavior that contributes to a positive environment for our
+community include:
 
-* Using welcoming and inclusive language
-* Being respectful of differing viewpoints and experiences
-* Gracefully accepting constructive criticism
-* Focusing on what is best for the community
-* Showing empathy towards other community members
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
 
-Examples of unacceptable behavior by participants include:
+Examples of unacceptable behavior include:
 
-* The use of sexualized language or imagery and unwelcome sexual attention or
- advances
-* Trolling, insulting/derogatory comments, and personal or political attacks
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
 * Public or private harassment
-* Publishing others' private information, such as a physical or electronic
- address, without explicit permission
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
 * Other conduct which could reasonably be considered inappropriate in a
- professional setting
+  professional setting
 
-## Our Responsibilities
+## Enforcement Responsibilities
 
-Project maintainers are responsible for clarifying the standards of acceptable
-behavior and are expected to take appropriate and fair corrective action in
-response to any instances of unacceptable behavior.
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
 
-Project maintainers have the right and responsibility to remove, edit, or
-reject comments, commits, code, wiki edits, issues, and other contributions
-that are not aligned to this Code of Conduct, or to ban temporarily or
-permanently any contributor for other behaviors that they deem inappropriate,
-threatening, offensive, or harmful.
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
 
 ## Scope
 
-This Code of Conduct applies both within project spaces and in public spaces
-when an individual is representing the project or its community. Examples of
-representing a project or community include using an official project e-mail
-address, posting via an official social media account, or acting as an appointed
-representative at an online or offline event. Representation of a project may be
-further defined and clarified by project maintainers.
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
 
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at ??? <!-- does MongoDB have an email for OSS CoC issues? -->. All
-complaints will be reviewed and investigated and will result in a response that
-is deemed necessary and appropriate to the circumstances. The project team is
-obligated to maintain confidentiality with regard to the reporter of an incident.
-Further details of specific enforcement policies may be posted separately.
+reported to the community leaders responsible for enforcement at
 
-Project maintainers who do not follow or enforce the Code of Conduct in good
-faith may face temporary or permanent repercussions as determined by other
-members of the project's leadership.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by [contacting GitHub][github-report-abuse]
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
-available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
 
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[github-report-abuse]: https://github.com/contact/report-abuse
 [homepage]: https://www.contributor-covenant.org
-
-For answers to common questions about this code of conduct, see
-https://www.contributor-covenant.org/faq
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ patterns and conventions used in Go code at MongoDB.
 
 See [MongoDB Go Style Guide](style.md) for the style guide.
 
+<!--
+
 ## Translations
 
 We are aware of the following translations of this guide by the Go community.
@@ -26,3 +28,5 @@ We are aware of the following translations of this guide by the Go community.
 - **Tiếng việt** (Vietnamese): [nc-minh/uber-go-guide-vi](https://github.com/nc-minh/uber-go-guide-vi)
 
 If you have a translation, feel free to submit a PR adding it to the list.
+
+-->

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-This repository holds the [Uber Go Style Guide](style.md), which documents
-patterns and conventions used in Go code at Uber.
+This repository holds the [MongoDB Go Style Guide](style.md), which documents
+patterns and conventions used in Go code at MongoDB.
 
 ## Style Guide
 
-See [Uber Go Style Guide](style.md) for the style guide.
+See [MongoDB Go Style Guide](style.md) for the style guide.
 
 ## Translations
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,18 @@ patterns and conventions used in Go code at MongoDB.
 
 See [MongoDB Go Style Guide](style.md) for the style guide.
 
+## MongoDB-Specific Changes
+
+This is a fork of [Uber's Go Style Guide](https://github.com/uber-go/guide/).
+
+At MongoDB, we aim to keep this guide as close to the upstream guide maintained by Uber as
+possible. However, there will inevitable by some points of divergence over time as we develop our
+own coding standards.
+
+When you make a change specific to this MongoDB fork, always update the
+[`CHANGELOG-MongoDB.md`](./CHANGELOG-MongoDB.md) file with a summary of what you changed. This makes
+it easier to reconcile differences between the Uber and MongoDB versions of this style guide.
+
 <!--
 
 ## Translations

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -1,4 +1,4 @@
-# Uber Go Style Guide
+# MongoDB Go Style Guide
 
 - [Introduction](intro.md)
 - Guidelines

--- a/src/intro.md
+++ b/src/intro.md
@@ -35,3 +35,10 @@ recommend setting up your editor to:
 
 You can find information in editor support for Go tools here:
 <https://go.dev/wiki/IDEsAndTextEditorPlugins>
+
+## MongoDB Style
+
+This style guide is a fork of the [Uber Style Guide](https://github.com/uber-go/guide) maintained by
+MongoDB. It is largely the same as Uber's. All changes specific to MongoDB are noted in the
+[CHANGELOG-MongoDB.md](./CHANGELOG-MongoDB.md) file. In addition, we have used HTML comments to make
+notes in most places where we have made changes from the Uber version.

--- a/style.md
+++ b/style.md
@@ -5,7 +5,7 @@
 
 <!-- markdownlint-disable MD033 -->
 
-# Uber Go Style Guide
+# MongoDB Go Style Guide
 
 - [Introduction](#introduction)
 - [Guidelines](#guidelines)
@@ -106,6 +106,13 @@ recommend setting up your editor to:
 
 You can find information in editor support for Go tools here:
 https://go.dev/wiki/IDEsAndTextEditorPlugins
+
+### MongoDB Style
+
+This style guide is a fork of the [Uber Style Guide](https://github.com/uber-go/guide) maintained by
+MongoDB. It is largely the same as Uber's. All changes specific to MongoDB are noted in the
+[CHANGELOG-MongoDB.md](src/CHANGELOG-MongoDB.md) file. In addition, we have used HTML comments to make
+notes in most places where we have made changes from the Uber version.
 
 ## Guidelines
 


### PR DESCRIPTION
This commit replaces some references to "Uber" with "MongoDB". It also adds a `CHANGELOG-MongoDB.md`
file and adds a note to the intro explaining that this Style Guide is a fork of Uber's.