### PR TITLE
Update linting and dev tool recommendations

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,7 +8,7 @@ run:
 linters:
   enable:
     - errcheck
-    - goimports
+    - gofumpt
     - govet
     - revive
     - staticcheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,8 +9,8 @@ linters:
   enable:
     - errcheck
     - goimports
-    - golint
     - govet
+    - revive
     - staticcheck
 
 issues:

--- a/CHANGELOG-MongoDB.md
+++ b/CHANGELOG-MongoDB.md
@@ -4,3 +4,5 @@
 - Recommend the new atomic types like `atomic.Bool` instead of the `go.uber.org/atomic` package. The
   Uber package predates the new types added in Go 1.19. The new stdlib types provide more or less
   the same functionality as Uber's package.
+- Replaced recommendation to use `golint` with `revive`, as `golint` is long since deprecated.
+

--- a/CHANGELOG-MongoDB.md
+++ b/CHANGELOG-MongoDB.md
@@ -6,4 +6,5 @@
   the same functionality as Uber's package.
 - Replaced recommendation to use `golint` with `revive`, as `golint` is long since deprecated.
 - Replaced recommendation to use `goimports` with `gofumpt`.
-
+- Added a recommendation to use `gopls` in general, and specifically to configure your editor to use
+  it to update imports.

--- a/CHANGELOG-MongoDB.md
+++ b/CHANGELOG-MongoDB.md
@@ -5,4 +5,5 @@
   Uber package predates the new types added in Go 1.19. The new stdlib types provide more or less
   the same functionality as Uber's package.
 - Replaced recommendation to use `golint` with `revive`, as `golint` is long since deprecated.
+- Replaced recommendation to use `goimports` with `gofumpt`.
 

--- a/CHANGELOG-MongoDB.md
+++ b/CHANGELOG-MongoDB.md
@@ -9,3 +9,4 @@
   intro to use `gofumpt` instead.
 - Added a recommendation to use `gopls` in general, and specifically to configure your editor to use
   it to update imports.
+- Added recommendations to use `golangci-lint` or `nogo` for linting orchestration.

--- a/CHANGELOG-MongoDB.md
+++ b/CHANGELOG-MongoDB.md
@@ -5,6 +5,7 @@
   Uber package predates the new types added in Go 1.19. The new stdlib types provide more or less
   the same functionality as Uber's package.
 - Replaced recommendation to use `golint` with `revive`, as `golint` is long since deprecated.
-- Replaced recommendation to use `goimports` with `gofumpt`.
+- Replaced recommendation to use `goimports` with `gofumpt`. Also fixed a reference to `gofmt` in the
+  intro to use `gofumpt` instead.
 - Added a recommendation to use `gopls` in general, and specifically to configure your editor to use
   it to update imports.

--- a/src/import-group.md
+++ b/src/import-group.md
@@ -5,7 +5,7 @@ There should be two import groups:
 - Standard library
 - Everything else
 
-This is the grouping applied by goimports by default.
+This is the grouping applied by gopls by default.
 
 <table>
 <thead><tr><th>Bad</th><th>Good</th></tr></thead>

--- a/src/intro.md
+++ b/src/intro.md
@@ -27,9 +27,14 @@ resources:
 We aim for the code samples to be accurate for the two most recent minor versions
 of Go [releases](https://go.dev/doc/devel/release).
 
+You should set up your editor to integrate with Go's LSP server, [gopls].
+
+  [gopls]: https://github.com/golang/tools/tree/master/gopls
+
 All code should be error-free when run through `revive` and `go vet`. We
 recommend setting up your editor to:
 
+- Use `gopls` to update your code's imports automatically on save
 - Run `gofumpt` on save
 - Run `revive` and `go vet` to check for errors
 

--- a/src/intro.md
+++ b/src/intro.md
@@ -30,7 +30,7 @@ of Go [releases](https://go.dev/doc/devel/release).
 All code should be error-free when run through `revive` and `go vet`. We
 recommend setting up your editor to:
 
-- Run `goimports` on save
+- Run `gofumpt` on save
 - Run `revive` and `go vet` to check for errors
 
 You can find information in editor support for Go tools here:

--- a/src/intro.md
+++ b/src/intro.md
@@ -2,7 +2,7 @@
 
 Styles are the conventions that govern our code. The term style is a bit of a
 misnomer, since these conventions cover far more than just source file
-formatting—gofmt handles that for us.
+formatting—gofumpt handles that for us.
 
 The goal of this guide is to manage this complexity by describing in detail the
 Dos and Don'ts of writing Go code at Uber. These rules exist to keep the code

--- a/src/intro.md
+++ b/src/intro.md
@@ -27,11 +27,11 @@ resources:
 We aim for the code samples to be accurate for the two most recent minor versions
 of Go [releases](https://go.dev/doc/devel/release).
 
-All code should be error-free when run through `golint` and `go vet`. We
+All code should be error-free when run through `revive` and `go vet`. We
 recommend setting up your editor to:
 
 - Run `goimports` on save
-- Run `golint` and `go vet` to check for errors
+- Run `revive` and `go vet` to check for errors
 
 You can find information in editor support for Go tools here:
 <https://go.dev/wiki/IDEsAndTextEditorPlugins>

--- a/src/intro.md
+++ b/src/intro.md
@@ -38,6 +38,12 @@ recommend setting up your editor to:
 - Run `gofumpt` on save
 - Run `revive` and `go vet` to check for errors
 
+Note that you may wish to use [golangci-lint] or Bazel's [nogo] to run `gofumpt`, `revive`, and `go
+vet` instead of running each one separately.
+
+  [golangci-lint]: https://golangci-lint.run/
+  [nogo]: https://github.com/bazel-contrib/rules_go/blob/master/go/nogo.rst
+
 You can find information in editor support for Go tools here:
 <https://go.dev/wiki/IDEsAndTextEditorPlugins>
 

--- a/src/lint.md
+++ b/src/lint.md
@@ -9,14 +9,14 @@ quality without being unnecessarily prescriptive:
 
 - [errcheck] to ensure that errors are handled
 - [goimports] to format code and manage imports
-- [golint] to point out common style mistakes
 - [govet] to analyze code for common mistakes
+- [revive] to point out common style mistakes
 - [staticcheck] to do various static analysis checks
 
   [errcheck]: https://github.com/kisielk/errcheck
   [goimports]: https://pkg.go.dev/golang.org/x/tools/cmd/goimports
-  [golint]: https://github.com/golang/lint
   [govet]: https://pkg.go.dev/cmd/vet
+  [revive]: https://github.com/mgechev/revive
   [staticcheck]: https://staticcheck.dev
 
 ## Lint Runners

--- a/src/lint.md
+++ b/src/lint.md
@@ -8,13 +8,13 @@ help to catch the most common issues and also establish a high bar for code
 quality without being unnecessarily prescriptive:
 
 - [errcheck] to ensure that errors are handled
-- [goimports] to format code and manage imports
+- [gofumpt] to format code and manage imports
 - [govet] to analyze code for common mistakes
 - [revive] to point out common style mistakes
 - [staticcheck] to do various static analysis checks
 
   [errcheck]: https://github.com/kisielk/errcheck
-  [goimports]: https://pkg.go.dev/golang.org/x/tools/cmd/goimports
+  [gofumpt]: https://github.com/mvdan/gofumpt
   [govet]: https://pkg.go.dev/cmd/vet
   [revive]: https://github.com/mgechev/revive
   [staticcheck]: https://staticcheck.dev

--- a/src/lint.md
+++ b/src/lint.md
@@ -21,7 +21,10 @@ quality without being unnecessarily prescriptive:
 
 ## Lint Runners
 
-We recommend [golangci-lint] as the go-to lint runner for Go code, largely due
+For projects which use Bazel, you should use [nogo] instead of [golangci-lint], as [golangci-lint]
+does not work well with Bazel's sandboxing.
+
+Otherwise, we recommend [golangci-lint] as the go-to lint runner for Go code, largely due
 to its performance in larger codebases and ability to configure and use many
 canonical linters at once. This repo has an example [.golangci.yml] config file
 with recommended linters and settings.
@@ -30,6 +33,7 @@ golangci-lint has [various linters] available for use. The above linters are
 recommended as a base set, and we encourage teams to add any additional linters
 that make sense for their projects.
 
+  [nogo]: https://github.com/bazel-contrib/rules_go/blob/master/go/nogo.rst
   [golangci-lint]: https://github.com/golangci/golangci-lint
   [.golangci.yml]: https://github.com/uber-go/guide/blob/master/.golangci.yml
   [various linters]: https://golangci-lint.run/usage/linters/

--- a/style.md
+++ b/style.md
@@ -107,6 +107,8 @@ recommend setting up your editor to:
 - Run `gofumpt` on save
 - Run `revive` and `go vet` to check for errors
 
+Note that you may wish to use [golangci-lint](https://golangci-lint.run/) or Bazel's [nogo](https://github.com/bazel-contrib/rules_go/blob/master/go/nogo.rst) to run `gofumpt`, `revive`, and `go vet` instead of running each one separately.
+
 You can find information in editor support for Go tools here:
 https://go.dev/wiki/IDEsAndTextEditorPlugins
 
@@ -4110,7 +4112,10 @@ quality without being unnecessarily prescriptive:
 
 ### Lint Runners
 
-We recommend [golangci-lint](https://github.com/golangci/golangci-lint) as the go-to lint runner for Go code, largely due
+For projects which use Bazel, you should use [nogo](https://github.com/bazel-contrib/rules_go/blob/master/go/nogo.rst) instead of [golangci-lint](https://github.com/golangci/golangci-lint), as [golangci-lint](https://github.com/golangci/golangci-lint)
+does not work well with Bazel's sandboxing.
+
+Otherwise, we recommend [golangci-lint](https://github.com/golangci/golangci-lint) as the go-to lint runner for Go code, largely due
 to its performance in larger codebases and ability to configure and use many
 canonical linters at once. This repo has an example [.golangci.yml](https://github.com/uber-go/guide/blob/master/.golangci.yml) config file
 with recommended linters and settings.

--- a/style.md
+++ b/style.md
@@ -98,9 +98,12 @@ resources:
 We aim for the code samples to be accurate for the two most recent minor versions
 of Go [releases](https://go.dev/doc/devel/release).
 
+You should set up your editor to integrate with Go's LSP server, [gopls](https://github.com/golang/tools/tree/master/gopls).
+
 All code should be error-free when run through `revive` and `go vet`. We
 recommend setting up your editor to:
 
+- Use `gopls` to update your code's imports automatically on save
 - Run `gofumpt` on save
 - Run `revive` and `go vet` to check for errors
 
@@ -2579,7 +2582,7 @@ There should be two import groups:
 - Standard library
 - Everything else
 
-This is the grouping applied by goimports by default.
+This is the grouping applied by gopls by default.
 
 <table>
 <thead><tr><th>Bad</th><th>Good</th></tr></thead>

--- a/style.md
+++ b/style.md
@@ -98,11 +98,11 @@ resources:
 We aim for the code samples to be accurate for the two most recent minor versions
 of Go [releases](https://go.dev/doc/devel/release).
 
-All code should be error-free when run through `golint` and `go vet`. We
+All code should be error-free when run through `revive` and `go vet`. We
 recommend setting up your editor to:
 
 - Run `goimports` on save
-- Run `golint` and `go vet` to check for errors
+- Run `revive` and `go vet` to check for errors
 
 You can find information in editor support for Go tools here:
 https://go.dev/wiki/IDEsAndTextEditorPlugins
@@ -4101,8 +4101,8 @@ quality without being unnecessarily prescriptive:
 
 - [errcheck](https://github.com/kisielk/errcheck) to ensure that errors are handled
 - [goimports](https://pkg.go.dev/golang.org/x/tools/cmd/goimports) to format code and manage imports
-- [golint](https://github.com/golang/lint) to point out common style mistakes
 - [govet](https://pkg.go.dev/cmd/vet) to analyze code for common mistakes
+- [revive](https://github.com/mgechev/revive) to point out common style mistakes
 - [staticcheck](https://staticcheck.dev) to do various static analysis checks
 
 ### Lint Runners

--- a/style.md
+++ b/style.md
@@ -76,7 +76,7 @@
 
 Styles are the conventions that govern our code. The term style is a bit of a
 misnomer, since these conventions cover far more than just source file
-formatting—gofmt handles that for us.
+formatting—gofumpt handles that for us.
 
 The goal of this guide is to manage this complexity by describing in detail the
 Dos and Don'ts of writing Go code at Uber. These rules exist to keep the code

--- a/style.md
+++ b/style.md
@@ -101,7 +101,7 @@ of Go [releases](https://go.dev/doc/devel/release).
 All code should be error-free when run through `revive` and `go vet`. We
 recommend setting up your editor to:
 
-- Run `goimports` on save
+- Run `gofumpt` on save
 - Run `revive` and `go vet` to check for errors
 
 You can find information in editor support for Go tools here:
@@ -4100,7 +4100,7 @@ help to catch the most common issues and also establish a high bar for code
 quality without being unnecessarily prescriptive:
 
 - [errcheck](https://github.com/kisielk/errcheck) to ensure that errors are handled
-- [goimports](https://pkg.go.dev/golang.org/x/tools/cmd/goimports) to format code and manage imports
+- [gofumpt](https://github.com/mvdan/gofumpt) to format code and manage imports
 - [govet](https://pkg.go.dev/cmd/vet) to analyze code for common mistakes
 - [revive](https://github.com/mgechev/revive) to point out common style mistakes
 - [staticcheck](https://staticcheck.dev) to do various static analysis checks


### PR DESCRIPTION
This makes the following changes:

- Recommends `revive` instead of the deprecated `golint`.
- Recommends `goimports` + `gofumpt` instead of `gofmt`.
- Recommends the use of `gopls`.
- Recommends using `golangci-lint` or `nogo` for linting orchestration.